### PR TITLE
Add The Remains of the Day to reading list

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,13 @@ type Book = {
 
 const BOOKS: Book[] = [
   {
+    title: 'The Remains of the Day',
+    author: 'Kazuo Ishiguro',
+    rating: '',
+    year: '2026',
+    href: 'https://www.amazon.com/Remains-Day-Kazuo-Ishiguro/dp/0679731725',
+  },
+  {
     title: 'The Snow Leopard',
     author: 'Peter Matthiessen',
     rating: '',


### PR DESCRIPTION
## Summary
- Add The Remains of the Day by Kazuo Ishiguro to the 2026 reading list
- Use verified Amazon product link: https://www.amazon.com/Remains-Day-Kazuo-Ishiguro/dp/0679731725

## Test Plan
- npm run build
- Verified Amazon URL returns 200 and product title matches The Remains of the Day